### PR TITLE
added an arc

### DIFF
--- a/example.py
+++ b/example.py
@@ -13,6 +13,7 @@ wedgedegree = 5.0
 
 # geometries
 radius_x = 0.19
+arc_x = 0.13
 length_z = 1.1
 
 # prepare ofblockmeshdicthelper.BlockMeshDict instance to
@@ -26,8 +27,10 @@ bmd.set_metric('m')
 basevs = [
     Vertex(0, 0, 0, 'v0'),
     Vertex(radius_x, 0, 0, 'v1'),
-    Vertex(radius_x, 0, length_z, 'v2'),
+    Vertex(radius_x, 1, length_z, 'v2'),
     Vertex(0, 0, length_z, 'v3')]
+# vertices for the arc
+arcvs = [Vertex(arc_x, 0, length_z/2.0, 'varc')]
 
 # rotate wedgedegree/2 around z axis
 # rotated vertices are named with '-y' or '+y' suffix.
@@ -38,10 +41,13 @@ sind = math.sin(math.radians(wedgedegree/2.0))
 for v in basevs:
     bmd.add_vertex(v.x*cosd, -v.x*sind, v.z, v.name+'-y')
     bmd.add_vertex(v.x*cosd,  v.x*sind, v.z, v.name+'+y')
+for v in arcvs:
+    bmd.add_vertex(v.x*cosd, -v.x*sind, v.z, v.name+'-y')
+    bmd.add_vertex(v.x*cosd,  v.x*sind, v.z, v.name+'+y')
 
 # v0+y and v3+y have same coordinate as v0-y and v3-y, respectively.
-bmd.reduce_vertex('v0-y', 'v0+y')
-bmd.reduce_vertex('v3-y', 'v3+y')
+#bmd.reduce_vertex('v0-y', 'v0+y')
+#bmd.reduce_vertex('v3-y', 'v3+y')
 
 
 # utility to to generate vertex names
@@ -66,7 +72,14 @@ bmd.add_boundary('patch', 'inlet', [b0.face('zm')])
 bmd.add_boundary('patch', 'outlet', [b0.face('zp')])
 bmd.add_boundary('empty', 'axis', [b0.face('xm')])
 
+bmd.add_arcedge(('v2-y', 'v3-y'), 'arc', 'varc-y')
+bmd.add_arcedge(('v2+y', 'v3+y'), 'arc', 'varc+y')
+
 # prepare for output
 bmd.assign_vertexid()
 # output
-print(bmd.format())
+#print(bmd.format())string = bmd.format()
+string = bmd.format()
+f = open("blockMeshDict", "w")
+f.write(string)
+f.close


### PR DESCRIPTION
Fails with:
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
/run/media/desperado/smb/daten/eigene_dateien/isl/messtechnik/stossrohr/selfmade/cfd/example_arc.py in <module>()
     80 # output
     81 #print(bmd.format())string = bmd.format()
---> 82 string = bmd.format()
     83 f = open("blockMeshDict", "w")
     84 f.write(string)

/usr/lib/python3.6/site-packages/ofblockmeshdicthelper/__init__.py in format(self)
    410 (
    411 );'''
--> 412 
    413     def format(self):
    414         template = Template(r'''/*--------------------------------*- C++ -*----------------------------------*\

/usr/lib/python3.6/site-packages/ofblockmeshdicthelper/__init__.py in format_edges_section(self)
    349             v.index = i
    350 
--> 351     def format_vertices_section(self):
    352         """format vertices section.
    353         assign_vertexid() should be called before this method, because

/usr/lib/python3.6/site-packages/ofblockmeshdicthelper/__init__.py in format(self, vertices)
    190     def __init__(self, vnames, name, interVertex):
    191         """Initialize ArcEdge instance
--> 192         vnames is the vertex names in order descrived in
    193           http://www.openfoam.org/docs/user/mesh-description.php
    194         # two vertices is needed for Arc

AttributeError: 'str' object has no attribute 'x'